### PR TITLE
Support ReadOnly flag during mounting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: true
 dist: trusty
-go: 1.9.x
+go: 1.13.x
 
 install: skip
 

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -34,6 +34,7 @@ func start(cmd *Cmd, target string) (*g8ufs.G8ufs, error) {
 		Target:    target,
 		Storage:   dataStore,
 		Reset:     cmd.Reset,
+		ReadOnly:  cmd.ReadOnly,
 	})
 }
 

--- a/g8ufs.go
+++ b/g8ufs.go
@@ -60,12 +60,10 @@ type G8ufs struct {
 
 func mountRO(target string, storage storage.Storage, meta meta.MetaStore, cache string) (*G8ufs, error) {
 	log.Debugf("ro: '%s' ca: %s", target, cache)
-	cfg := rofs.NewConfig(storage, meta, cache)
-	var server *fuse.Server
 
+	cfg := rofs.NewConfig(storage, meta, cache)
 	fs := rofs.New(cfg)
-	var err error
-	server, err = fuse.NewServer(
+	server, err := fuse.NewServer(
 		nodefs.NewFileSystemConnector(
 			pathfs.NewPathNodeFs(fs, nil).Root(),
 			nil,
@@ -86,6 +84,7 @@ func mountRO(target string, storage storage.Storage, meta meta.MetaStore, cache 
 	}
 	log.Debugf("Waiting for fuse mount")
 	if err := server.WaitMount(); err != nil {
+		server.Unmount()
 		return nil, fmt.Errorf("failed to wait for fuse mount: %s", err)
 	}
 

--- a/g8ufs.go
+++ b/g8ufs.go
@@ -82,11 +82,9 @@ func mountRO(target string, storage storage.Storage, meta meta.MetaStore, cache 
 		Config: cfg,
 		layers: []string{target},
 	}
+
 	log.Debugf("Waiting for fuse mount")
-	if err := server.WaitMount(); err != nil {
-		server.Unmount()
-		return nil, fmt.Errorf("failed to wait for fuse mount: %s", err)
-	}
+	server.WaitMount()
 
 	return zfs, nil
 }


### PR DESCRIPTION
This change doesn't require a `rw` layer so the fuse is mounted directly into the target path.

This change is require by https://github.com/threefoldtech/zos/issues/371 to avoid creating a RW subvolume for flists that are just needed in `ro` mode