### PR TITLE
fix connection management in redis pool

### DIFF
--- a/storage/router/pool.go
+++ b/storage/router/pool.go
@@ -101,6 +101,7 @@ func (p *ScanPool) newPool(d Destination) *redis.Pool {
 			return nil
 		},
 		MaxActive:   10,
+		MaxIdle:     2,
 		IdleTimeout: 1 * time.Minute,
 		Wait:        true,
 	}

--- a/storage/router/pool.go
+++ b/storage/router/pool.go
@@ -100,8 +100,8 @@ func (p *ScanPool) newPool(d Destination) *redis.Pool {
 
 			return nil
 		},
-		MaxActive:   10,
-		MaxIdle:     2,
+		MaxActive:   12,
+		MaxIdle:     4,
 		IdleTimeout: 1 * time.Minute,
 		Wait:        true,
 	}


### PR DESCRIPTION
The pool configuration requires to have the MaxIdle connection to a
number bigger then 1 to allow to reuse connection.
Without it a new connection is always created.

This commit allow to have a total of 10 connection in the pool and keep
2 of them open.