### PR TITLE
Implement a walk function

### DIFF
--- a/meta/layer.go
+++ b/meta/layer.go
@@ -71,6 +71,15 @@ func (s stores) Get(p string) (Meta, bool) {
 	return nil, false
 }
 
+func (s stores) Close() error {
+	// TODO: aggregate all the errors
+	for _, store := range s {
+		store.Close()
+	}
+
+	return nil
+}
+
 // Layered return a meta store that layer the given stores in a way that last store is on top
 // Example:
 //  store = Layered(s1, s2)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"errors"
 	"fmt"
 	"syscall"
 
@@ -99,8 +100,30 @@ type Meta interface {
 	Children() []Meta
 }
 
+// WalkFn walk function
+type WalkFn func(path string, meta Meta) error
+
+// ErrSkipDir if returned by the WalkFn the directory is skipped
+var ErrSkipDir = errors.New("skip this directory")
+
 // Store is the interface to implement to read filesystem metadata from an flist
 type Store interface {
 	// Populate(entry Entry) error
 	Get(name string) (Meta, bool)
+}
+
+// Walker interface, some stores can implement this interface
+type Walker interface {
+	// Walk walks over the given path and call fn for each entry
+	// that is found under this given path, including `path` itself
+	// Note the following:
+	// - if fn return ErrSkipDir and meta.IsDir() is true
+	//   then this directory is not scanned.
+	// - if fn return ErrSkipDir and meta.IsDir() is false
+	//   then the remaining items of the current directory are skipped
+	// - Walk does not follow symlinks, so if the meta.IsDir() is false
+	//   extra checks can be done on the "file" type from the meta.Info()
+	//   if Type is SymLink the caller can decide to read the Target and
+	//   follow the link
+	Walk(path string, fn WalkFn) error
 }

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -110,10 +110,12 @@ var ErrSkipDir = errors.New("skip this directory")
 type Store interface {
 	// Populate(entry Entry) error
 	Get(name string) (Meta, bool)
+	Close() error
 }
 
 // Walker interface, some stores can implement this interface
 type Walker interface {
+	Store
 	// Walk walks over the given path and call fn for each entry
 	// that is found under this given path, including `path` itself
 	// Note the following:

--- a/meta/store.go
+++ b/meta/store.go
@@ -93,6 +93,11 @@ type sqlStore struct {
 	groupsM sync.Mutex
 }
 
+func (s *sqlStore) Close() error {
+	_ = s.stmt.Close()
+	return s.db.Close()
+}
+
 func (s *sqlStore) hash(path string) string {
 	hasher, _ := blake2b.New(16, nil)
 	io.WriteString(hasher, path)

--- a/meta/unpack.go
+++ b/meta/unpack.go
@@ -1,0 +1,51 @@
+package meta
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path"
+)
+
+// Unpack decrompress and unpack a tgz (flist) archive from r to dest folder
+// dest is created is it doesn't exist
+func Unpack(r io.Reader, dest string) error {
+	err := os.MkdirAll(dest, 0770)
+	if err != nil {
+		return err
+	}
+
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(zr)
+	// Iterate through the files in the archive.
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Name == "/" || hdr.Name == "./" {
+			continue
+		}
+
+		f, err := os.OpenFile(path.Join(dest, hdr.Name), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
+		if err != nil {
+			log.Errorf("%s", err)
+			return err
+		}
+		if _, err := io.Copy(f, tr); err != nil {
+			return err
+		}
+
+		f.Close()
+	}
+
+	return err
+}

--- a/rofs/cache.go
+++ b/rofs/cache.go
@@ -96,9 +96,9 @@ func (fs *filesystem) checkAndGet(m meta.Meta) (*os.File, error) {
 // download file from storage
 func (fs *filesystem) download(file *os.File, m meta.Meta) error {
 	downloader := Downloader{
-		Storage:   fs.storage,
-		BlockSize: m.Info().FileBlockSize,
-		Blocks:    m.Blocks(),
+		storage:   fs.storage,
+		blockSize: m.Info().FileBlockSize,
+		blocks:    m.Blocks(),
 	}
 
 	return downloader.Download(file)

--- a/rofs/downloader_test.go
+++ b/rofs/downloader_test.go
@@ -1,4 +1,4 @@
-package rofs_test
+package rofs
 
 import (
 	"bytes"
@@ -15,7 +15,7 @@ import (
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/assert"
 	"github.com/threefoldtech/0-fs/meta"
-	"github.com/threefoldtech/0-fs/rofs"
+
 	"github.com/xxtea/xxtea-go/xxtea"
 )
 
@@ -73,10 +73,10 @@ func TestDownloadSuccess(t *testing.T) {
 	//initialize test data
 	storage, blocks := MakeStorage(20)
 
-	downloader := rofs.Downloader{
-		Storage:   storage,
-		Blocks:    blocks,
-		BlockSize: ChunkSize,
+	downloader := Downloader{
+		storage:   storage,
+		blocks:    blocks,
+		blockSize: ChunkSize,
 	}
 
 	out, err := ioutil.TempFile("", "dt-")
@@ -108,10 +108,10 @@ func TestDownloadFailure(t *testing.T) {
 	//initialize test data
 	storage, blocks := MakeStorage(20)
 
-	downloader := rofs.Downloader{
-		Storage:   storage,
-		Blocks:    blocks,
-		BlockSize: ChunkSize,
+	downloader := Downloader{
+		storage:   storage,
+		blocks:    blocks,
+		blockSize: ChunkSize,
 	}
 
 	//drop some blocks
@@ -138,11 +138,11 @@ func TestDownloadSingle(t *testing.T) {
 	//initialize test data
 	storage, blocks := MakeStorage(20)
 
-	downloader := rofs.Downloader{
-		Storage:   storage,
-		Blocks:    blocks,
-		BlockSize: ChunkSize,
-		Workers:   1,
+	downloader := Downloader{
+		storage:   storage,
+		blocks:    blocks,
+		blockSize: ChunkSize,
+		workers:   1,
 	}
 
 	out, err := ioutil.TempFile("", "dt-")


### PR DESCRIPTION
Note: a new interface Walker is introduced because it's not possible for all store types to implement the Walker interface. Hence once a store is created an explicit check can be done to see if this store supports it or not.