### PR TITLE
rofs: do not forward permissions from cache when file are already open

### DIFF
--- a/g8ufs.go
+++ b/g8ufs.go
@@ -63,11 +63,15 @@ func mountRO(target string, storage storage.Storage, meta meta.Store, cache stri
 
 	cfg := rofs.NewConfig(storage, meta, cache)
 	fs := rofs.New(cfg)
+	// opts := nodefs.Options{Debug: true}
+	opts := nodefs.Options{}
+
 	server, err := fuse.NewServer(
 		nodefs.NewFileSystemConnector(
 			pathfs.NewPathNodeFs(fs, nil).Root(),
-			&nodefs.Options{},
+			&opts,
 		).RawFS(), target, &fuse.MountOptions{
+			// Debug:         true,
 			AllowOther:    true,
 			FsName:        "g8ufs",
 			DisableXAttrs: true,

--- a/rofs/rofs.go
+++ b/rofs/rofs.go
@@ -217,6 +217,8 @@ type WithAttr struct {
 	Source *fuse.Attr
 }
 
+// GetAttr override loopback GetAttr and forward stored
+// attributes from backend and not local file
 func (w *WithAttr) GetAttr(out *fuse.Attr) fuse.Status {
 	*out = *w.Source
 	return fuse.OK

--- a/rofs/rofs.go
+++ b/rofs/rofs.go
@@ -143,10 +143,10 @@ func (fs *filesystem) Open(name string, flags uint32, context *fuse.Context) (no
 	// for fd in cache later (no new GetAttr will be done
 	// if the file is already open and it will forward
 	// local cache file attrs)
-	attr, err := fs.GetAttr(name, context)
-	if err != fuse.OK {
-		log.Errorf("Failed to fetch original attr: %s", err)
-		return nil, err
+	attr, ferr := fs.GetAttr(name, context)
+	if ferr != fuse.OK {
+		log.Errorf("Failed to fetch original attr: %s", ferr)
+		return nil, ferr
 	}
 
 	file := &WithAttr{

--- a/rofs/rofs.go
+++ b/rofs/rofs.go
@@ -105,6 +105,9 @@ func (fs *filesystem) GetAttr(name string, context *fuse.Context) (*fuse.Attr, f
 		size = uint64(len(info.LinkTarget))
 	}
 
+	// log.Debugf("mode: %v %#o", nodeType, access.Mode)
+	// log.Debugf("owner: uid %v gid %v", access.UID, access.GID)
+
 	return &fuse.Attr{
 		Ino:    ino,
 		Size:   size,
@@ -136,7 +139,22 @@ func (fs *filesystem) Open(name string, flags uint32, context *fuse.Context) (no
 		log.Errorf("Failed to open/download the file: %s", err)
 	}
 
-	return nodefs.NewReadOnlyFile(nodefs.NewLoopbackFile(f)), fuse.OK
+	// fetch original attr and store them to reuse
+	// for fd in cache later (no new GetAttr will be done
+	// if the file is already open and it will forward
+	// local cache file attrs)
+	attr, err := fs.GetAttr(name, context)
+	if err != fuse.OK {
+		log.Errorf("Failed to fetch original attr: %s", err)
+		return nil, err
+	}
+
+	file := &WithAttr{
+		File:   nodefs.NewLoopbackFile(f),
+		Source: attr,
+	}
+
+	return nodefs.NewReadOnlyFile(file), fuse.OK
 }
 
 func (fs *filesystem) OpenDir(name string, context *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
@@ -190,4 +208,16 @@ func (fs *filesystem) ListXAttr(name string, context *fuse.Context) ([]string, f
 
 func (fs *filesystem) StatFs(name string) *fuse.StatfsOut {
 	return &fuse.StatfsOut{}
+}
+
+// WithAttr override nodefs.File with custom GetAttr
+// which use attr from rofs and not local file
+type WithAttr struct {
+	nodefs.File
+	Source *fuse.Attr
+}
+
+func (w *WithAttr) GetAttr(out *fuse.Attr) fuse.Status {
+	*out = *w.Source
+	return fuse.OK
 }


### PR DESCRIPTION
When a file is open, a loopback handler is returned and attribute from local cache is used for underlaying call.

This cause mismatch attributes (permissions, owner, ...) as expected when a file is already open and attributes are requested.

This fix this behavior. A copy of expected attributes are saved during the Open call request and theses attributes are returned for underlaying calls.

This is a possible fix for https://github.com/threefoldtech/0-flist/issues/32